### PR TITLE
Made sleep command more portable

### DIFF
--- a/scripting.yml
+++ b/scripting.yml
@@ -18,6 +18,6 @@ application:
           execute: receive-command(string script, object arguments => object results)
       configuration:
         docker.image: "{$.configuration.image}:{$.configuration.version}"
-        docker.command: [ "sleep", "inf" ]
+        docker.command: [ "sh", "-c", "while true; do sleep 1024d; done" ]
         docker.commands:
           scripting.execute: [ "/invoke.py"  ]


### PR DESCRIPTION
A followup for https://github.com/qubell-bazaar/dockerfiles/pull/6

busybox `sleep` does not support `inf` argument, it is a GNU extension. This change is necessary since alpine uses busybox.
